### PR TITLE
fix: WP_DEBUGが有効状態で、wordpressログイン画面を表示した時、Warningメッセージが出てリダイレクトやcooki…

### DIFF
--- a/functions/autoload/35_gutenberg.php
+++ b/functions/autoload/35_gutenberg.php
@@ -91,7 +91,7 @@ add_action('after_setup_theme', function () {
     /**
      * フォントサイズ変更を無効化
      */
-    add_theme_support('editor-font-sizes');
+    add_theme_support('editor-font-sizes', array());
     add_theme_support('disable-custom-font-sizes');
 
     /**


### PR DESCRIPTION

### **発生状況**
WP_DEBUGが有効状態で、wordpressログイン画面を表示した時、Warningメッセージが出てリダイレクトやcookieが動作しない。
/wp-admin/
/wp-login.php

### **エラーメッセージ**
```
Warning: Invalid argument supplied for foreach() in /var/www/html/wp-includes/class-wp-theme-json.php on line 2056
```

### **発生原因**
functions/autoload/35_gutenberg.php 中段くらい。
以下の記述。
```
    /**
     * フォントサイズ変更を無効化
     */
    add_theme_support('editor-font-sizes');
```

### **対処**
第二引数に空配列を渡す。
```
    /**
     * フォントサイズ変更を無効化
     */
    add_theme_support('editor-font-sizes',array());
```

### **詳細**
WPデフォルトで、ブロックエディタで段落等を追加した時、フォントサイズを変更できます。このサイズ変更できる値を、テーマで上書きできるのが上記記述です。
LIGテンプレートでは、この機能がデフォルトで無効化されています。その記述が今回の問題原因でした。
add_theme_support関数でeditor-font-sizeを指定する場合、本来であれば第二引数として、変更できるサイズを配列で渡す必要がありますが、無効化するために第二引数を省略しています。
これが色々な処理を流れて、class-wp-theme-json.php L2056で 配列ではない何らかの形で渡ってしまい、上記エラーメッセージが出たのだと思います。
なので、無効化する時は第二引数に空配列を渡せば良いと思った次第です。
add_theme_support関数でeditor-font-sizesを使う時の設定は、以下で紹介されていました。
[https://ja.wordpress.org/team/handbook/block-editor/how-to-guides/themes/theme-support/#%E3%83%96%E3%83%AD%E3%83%83%E3%82%AF%E3%83%95%E3%82%A9%E3%83%B3%E3%83%88%E3%82%B5%E3%82%A4%E3%82%BA](https://ja.wordpress.org/team/handbook/block-editor/how-to-guides/themes/theme-support/#%E3%83%96%E3%83%AD%E3%83%83%E3%82%AF%E3%83%95%E3%82%A9%E3%83%B3%E3%83%88%E3%82%B5%E3%82%A4%E3%82%BA
)



・wp-adminにアクセスした時のエラー画面
![wp-adminにアクセスした時のエラー画面](https://user-images.githubusercontent.com/47776346/175851640-21ecc93d-aab7-4956-864e-b89c1c194880.png)

・wp-login phpにアクセスした時のエラー画面
![wp-login phpにアクセスした時のエラー画面](https://user-images.githubusercontent.com/47776346/175851741-31f3d2a7-47b9-4452-b135-db1b0a466d21.png)

彌永さんからです。
直近の案件でこの問題に直面したので取り込んでいただけると幸いです。
